### PR TITLE
Fix PF2e 5.2 CONFIG.PF2E.attributes deprecation

### DIFF
--- a/scripts/pf2e.js
+++ b/scripts/pf2e.js
@@ -4,7 +4,13 @@ import {ask_initiative} from './bin.js'
 
 export class pf2eCombat {
 	constructor() {
-		this.init_options = "<option value='perception'>" + game.i18n.localize("PF2E.PerceptionLabel") + "</option>"
+		//PF2e 5.2.0 update to perception flag
+		if (isNewerVersion(game.settings.version, "5.2.0")) {
+			this.init_options = "<option value='perception'>" + game.i18n.localize("PF2E.PerceptionLabel") + "</option>"
+		}
+		else {
+			this.init_options = "<option value='perception'>" + game.i18n.localize(CONFIG.PF2E.attributes.perception) + "</option>"
+		}
 		var keys = Object.keys(CONFIG.PF2E.skillList)
 		for (var i = 0; i < keys.length; i++) {
 			var key = keys[i]

--- a/scripts/pf2e.js
+++ b/scripts/pf2e.js
@@ -4,7 +4,7 @@ import {ask_initiative} from './bin.js'
 
 export class pf2eCombat {
 	constructor() {
-		this.init_options = "<option value='perception'>" + game.i18n.localize(CONFIG.PF2E.attributes.perception) + "</option>"
+		this.init_options = "<option value='perception'>" + game.i18n.localize("PF2E.PerceptionLabel") + "</option>"
 		var keys = Object.keys(CONFIG.PF2E.skillList)
 		for (var i = 0; i < keys.length; i++) {
 			var key = keys[i]


### PR DESCRIPTION
Just a small fix to correctly point at the new perception label in PF2e 5.2 onwards (the old method is being deprecated in 6.0)

This won't be backwards compatible - but happy to add a conditional to check for system version if that's preferred.